### PR TITLE
Add start_hidden option

### DIFF
--- a/metadata/hide-cursor.xml
+++ b/metadata/hide-cursor.xml
@@ -15,5 +15,10 @@
             <default>2000</default>
             <min>250</min>
         </option>
+        <option name="start_hidden" type="bool">
+            <_short>Start with the cursor hidden</_short>
+            <_long>If disabled the cursor will start shown.</_long>
+            <default>false</default>
+        </option>
     </plugin>
 </wayfire>

--- a/src/hide-cursor.cpp
+++ b/src/hide-cursor.cpp
@@ -36,12 +36,14 @@ namespace wf_hide_cursor
     class wayfire_hide_cursor
     {
         wf::option_wrapper_t<int> hide_delay{"hide-cursor/hide_delay"};
+        wf::option_wrapper_t<bool> start_hidden{"hide-cursor/start_hidden"};
         wf::wl_timer hide_timer;
 
     public:
         wayfire_hide_cursor()
         {
-            hidden = false;
+            if (start_hidden) wf::get_core().hide_cursor();
+            hidden = start_hidden;
             setup_hide_timer();
             wf::get_core().connect_signal("pointer_motion", &pointer_motion);
         }


### PR DESCRIPTION
By default the cursor will start shown when wayfire starts. This option allows the cursor to start hidden.

This is especially useful when running wayfire as a kiosk without a mouse attached so that the cursor is never visible.